### PR TITLE
chore: upgrade from node:14-alpine to node:16-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:16-alpine
 
 # Install system packages
 RUN apk add --no-cache \


### PR DESCRIPTION
Upgrade from Node.js v14 to Node.js v16.